### PR TITLE
refactor: enforce required DB_CONNECTION_STRING across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ sequenceDiagram
 - `Submission`: participant answer with computed `Score` and `Time`
 - `Team`, `TeamMember`, `TeamLeader`
 - `User`, `Role`, `RolePermission`, `UserPermission`, `UserRole`, `UserPrompt`
-- `Bot` (type: BackOffice/GameAdmin/GameServer)
+- `Bot` (type: BackOffice/GameAdmin/GameServer/LoadBalancer/Universal)
 - `Mailing`, `MailingProfile`, and Filters (by Bot/BotType/Game/Session/Team/User)
 
 ## Messaging (Kafka)
@@ -151,8 +151,10 @@ Consumers ensure topics exist at startup and isolate per-bot streams with dedica
 All configuration is via environment variables. Below are commonly used settings per service.
 
 ### Common
-- `DB_CONNECTION_STRING`: PostgreSQL connection string (optional for sender if only HTTP)
+- `DB_CONNECTION_STRING`: PostgreSQL connection string (required by all services)
 - `KAFKA_BOOTSTRAP_SERVERS`: Kafka bootstrap servers (e.g., `localhost:9092`)
+- `KAFKA_DEFAULT_NUM_PARTITIONS`: default `1` (applied by all consumers when autocreating topics)
+- `KAFKA_DEFAULT_REPLICATION_FACTOR`: default `1` (applied by all consumers when autocreating topics)
 - `SENTRY_DSN`: Optional Sentry DSN
 - `LOCALE`: Default `en` (supports `ru` resources)
 
@@ -173,13 +175,11 @@ All configuration is via environment variables. Below are commonly used settings
 - `CRYPTO_PASSWORD`: symmetric key to decrypt QR payloads
 - `QR_CODE_EXPIRATION_SECONDS`: default `0` (no expiration)
 - `KAFKA_CONSUMER_GROUP_ID`: default `Quizitor.Bots`
-- `KAFKA_DEFAULT_NUM_PARTITIONS`: default `1` (override e.g., `3` locally)
-- `KAFKA_DEFAULT_REPLICATION_FACTOR`: default `1`
 - `REDIS_CONNECTION_STRING`, `REDIS_KEY_PREFIX`
 
 ### Sender (`src/Quizitor.Sender`)
 - `PORT`: required
-- `DB_CONNECTION_STRING` (optional)
+- `DB_CONNECTION_STRING`
 - `TELEGRAM_BOT_TOKEN`: backoffice token for default channel
 - `WORKING_DIRECTORY`: default `/var/quizitor`
 - `KAFKA_CONSUMER_GROUP_ID`: e.g., `Quizitor.Sender`

--- a/src/Quizitor.Api/Configuration/AppConfiguration.cs
+++ b/src/Quizitor.Api/Configuration/AppConfiguration.cs
@@ -13,6 +13,6 @@ public static class AppConfiguration
     public static readonly string? PathBase = "PATH_BASE"
         .GetEnvironmentVariable();
 
-    public static readonly string? DbConnectionString = "DB_CONNECTION_STRING"
-        .GetEnvironmentVariable();
+    public static readonly string DbConnectionString = "DB_CONNECTION_STRING"
+        .GetEnvironmentVariableOrThrowIfNullOrWhiteSpace();
 }

--- a/src/Quizitor.Api/appsettings.Development.json
+++ b/src/Quizitor.Api/appsettings.Development.json
@@ -5,8 +5,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "ConnectionStrings": {
-    "Default": "Server=localhost;Port=5432;Database=quizitor;User Id=postgres;Password=postgres"
   }
 }

--- a/src/Quizitor.Bots/Configuration/AppConfiguration.cs
+++ b/src/Quizitor.Bots/Configuration/AppConfiguration.cs
@@ -10,8 +10,8 @@ public static class AppConfiguration
     public static readonly string Port = "PORT"
         .GetEnvironmentVariableOrThrowIfNullOrWhiteSpace();
 
-    public static readonly string? DbConnectionString = "DB_CONNECTION_STRING"
-        .GetEnvironmentVariable();
+    public static readonly string DbConnectionString = "DB_CONNECTION_STRING"
+        .GetEnvironmentVariableOrThrowIfNullOrWhiteSpace();
 
     public static readonly string WorkingDirectory = "WORKING_DIRECTORY"
         .GetEnvironmentVariableWithFallbackValue("/var/quizitor");

--- a/src/Quizitor.Sender/Configuration/AppConfiguration.cs
+++ b/src/Quizitor.Sender/Configuration/AppConfiguration.cs
@@ -7,8 +7,8 @@ public static class AppConfiguration
     public static readonly string Port = "PORT"
         .GetEnvironmentVariableOrThrowIfNullOrWhiteSpace();
 
-    public static readonly string? DbConnectionString = "DB_CONNECTION_STRING"
-        .GetEnvironmentVariable();
+    public static readonly string DbConnectionString = "DB_CONNECTION_STRING"
+        .GetEnvironmentVariableOrThrowIfNullOrWhiteSpace();
 
     public static readonly string WorkingDirectory = "WORKING_DIRECTORY"
         .GetEnvironmentVariableWithFallbackValue("/var/quizitor");


### PR DESCRIPTION
- Updated README.md to clarify that DB_CONNECTION_STRING is required for all services.
- Modified AppConfiguration.cs in Quizitor.Api, Quizitor.Bots, and Quizitor.Sender to throw an error if DB_CONNECTION_STRING is not set, ensuring better error handling.
- Removed the default connection string from appsettings.Development.json for Quizitor.Api.