### PR TITLE
feat: enhance logging in LogInteractionUniv to include BotUsername in warning messages

### DIFF
--- a/src/Quizitor.Bots/Behaviors/Universal/LogInteractionUniv.cs
+++ b/src/Quizitor.Bots/Behaviors/Universal/LogInteractionUniv.cs
@@ -29,7 +29,8 @@ internal sealed class LogInteractionUniv(ILogger<LogInteractionUniv> logger) :
     {
         logger
             .LogWarning(
-                "CLB {FromId} {Data}",
+                "CLB {BotUsername} {FromId} {Data}",
+                context.Base.EntryBot?.Username,
                 context.CallbackQueryFromId,
                 context.CallbackQueryDataPostfix);
         return Task.CompletedTask;
@@ -41,7 +42,8 @@ internal sealed class LogInteractionUniv(ILogger<LogInteractionUniv> logger) :
     {
         logger
             .LogWarning(
-                "MSG {FromId} {Text}",
+                "MSG {BotUsername} {FromId} {Text}",
+                context.Base.EntryBot?.Username,
                 context.MessageFromId,
                 context.MessageText);
         return Task.CompletedTask;
@@ -55,7 +57,8 @@ internal sealed class LogInteractionUniv(ILogger<LogInteractionUniv> logger) :
     {
         logger
             .LogWarning(
-                "QRC {FromId} {Text}",
+                "QRC {BotUsername} {FromId} {Text}",
+                context.Base.EntryBot?.Username,
                 context.MessageFromId,
                 context.QrCodeDataPostfix);
         return Task.CompletedTask;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds bot username to warning logs in `LogInteractionUniv` for callback queries, messages, and QR code scans.
> 
> - **Logging**:
>   - Update warning templates in `LogInteractionUniv` to include `BotUsername`:
>     - `PerformCallbackQueryDataPrefixAsync`: `"CLB {BotUsername} {FromId} {Data}"` with `context.Base.EntryBot?.Username`.
>     - `PerformMessageTextAsync`: `"MSG {BotUsername} {FromId} {Text}"` with `context.Base.EntryBot?.Username`.
>     - `PerformQrCodeDataPrefixAsync`: `"QRC {BotUsername} {FromId} {Text}"` with `context.Base.EntryBot?.Username`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd6e3f9cdb8984647cabb943b1ff3afb48deeca5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->